### PR TITLE
Update GitHub pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,31 +12,31 @@
   <div id="wrap">
     <div id="sidebar">
       <a href="index.html"><img src="resources/aegean-logo-v1.0-256.png" alt="AEGeAn logo" style="margin-bottom: 30px;" /></a>
-      
+
       <ul>
-        <li><a href="https://github.com/standage/AEGeAn" title="AEGeAn at GitHub">Source code</a><br />AEGeAn source code at GitHub</li>
-        <li><a href="https://github.com/standage/AEGeAn/releases" title="Stable releases of the AEGeAn toolkit">Releases</a><br />Stable toolkit releases</li>
+        <li><a href="https://github.com/BrendelGroup/AEGeAn" title="AEGeAn at GitHub">Source code</a><br />AEGeAn source code on GitHub</li>
+        <li><a href="https://github.com/BrendelGroup/AEGeAn/releases" title="Stable releases of the AEGeAn toolkit">Releases</a><br />Stable toolkit releases</li>
         <li><a href="http://aegean.readthedocs.org" title="Documentation for AEGeAn">Documentation</a><br />Read the docs</li>
         <li><a href="http://standage.github.io" title="Daniel Standage's CV">Author</a><br />Daniel Standage</li>
       </ul>
     </div>
-  
+
     <div id="content">
       <h2>Integrated genome analysis toolkit</h2>
       <p>
-        The AEGeAn Toolkit is designed for the <strong>A</strong>nalysis and <strong>E</strong>valuation of <strong>Ge</strong>nome <strong>An</strong>notations. The toolkit includes a variety of analysis programs as well as a C library whose API provides access to AEGeAn's core functions and data structures. AEGeAn is free to use and is released under an unrestrictive open source <a href="https://github.com/standage/AEGeAn/blob/master/LICENSE" title="AEGeAn license">license</a>.
+        The AEGeAn Toolkit is designed for the <strong>A</strong>nalysis and <strong>E</strong>valuation of <strong>Ge</strong>nome <strong>An</strong>notations. The toolkit includes a variety of analysis programs as well as a C library whose API provides access to AEGeAn's core functions and data structures. AEGeAn is free to use and is released under an unrestrictive open source <a href="https://github.com/BrendelGroup/AEGeAn/blob/master/LICENSE" title="AEGeAn license">license</a>.
       </p>
 
       <h3>Documentation</h3>
       <p>Preliminary documentation for the AEGeAn Toolkit, including download and installation instructions, API documentation, and program guides is available at <a href="http://aegean.readthedocs.org" title="Documentation for AEGeAn">http://aegean.readthedocs.org</a>.</p>
 
       <h3>Publications</h3>
-      <p><strong>Daniel S. Standage</strong> and Volker P. Brendel (2012) ParsEval: parallel comparison and analysis of gene structure annotations. <em>BMC Bioinformatics</em>, <strong>13</strong>:187, <a href="http://dx.doi.org/10.1186/1471-2105-13-187" target="_blank">doi:10.1186/1471-2105-13-187</a>.</p>
+      <p>Daniel S. Standage and Volker P. Brendel (2012) ParsEval: parallel comparison and analysis of gene structure annotations. <em>BMC Bioinformatics</em>, <strong>13</strong>:187, <a href="http://dx.doi.org/10.1186/1471-2105-13-187" target="_blank">doi:10.1186/1471-2105-13-187</a>.</p>
 
       <h3>Support</h3>
-      <p>If you have any questions or encounter any issues running the software, please use <a href="https://github.com/standage/AEGeAn/issues" title="Issue tracker for AEGeAn on GitHub">AEGeAn's issue tracker on GitHub</a>. I receive an email notification with each issue submitted and will do my best to respond quickly.</p>
+      <p>If you have any questions or encounter any issues running the software, please use <a href="https://github.com/BrendelGroup/AEGeAn/issues" title="Issue tracker for AEGeAn on GitHub">AEGeAn's issue tracker on GitHub</a>. We receive an email notification with each issue submitted and will do our best to respond quickly.</p>
 
-      <p class="credits">&copy; 2010-2014 Daniel S. Standage | Template design by <a href="http://andreasviklund.com">Andreas Viklund</a></p>
+      <p class="credits">&copy; 2010-2016 Brendel Group, Indiana University | Template design by <a href="http://andreasviklund.com">Andreas Viklund</a></p>
     </div>
   </div>
   </body>


### PR DESCRIPTION
Links now point to BrendelGroup/AEGeAn rather than standage/AEGeAn.