### PR TITLE
TSV output for GAEVAL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,11 @@ env:
 before_install:
   - sudo apt-get update
   - sudo apt-get install -y libcairo2-dev libpango1.0-dev valgrind
-  - wget http://genometools.org/pub/binary_distributions/gt-1.5.8-Linux_x86_64-64bit-complete.tar.gz
-  - tar xzf gt-1.5.8-Linux_x86_64-64bit-complete.tar.gz
-  - sudo cp -r gt-1.5.8-Linux_x86_64-64bit-complete/bin/* /usr/local/bin/
-  - sudo cp -r gt-1.5.8-Linux_x86_64-64bit-complete/include/genometools /usr/local/include/
-  - sudo cp -r gt-1.5.8-Linux_x86_64-64bit-complete/lib/* /usr/local/lib/
+  - wget http://genometools.org/pub/binary_distributions/gt-1.5.9-Linux_x86_64-64bit-complete.tar.gz
+  - tar xzf gt-1.5.9-Linux_x86_64-64bit-complete.tar.gz
+  - sudo cp -r gt-1.5.9-Linux_x86_64-64bit-complete/bin/* /usr/local/bin/
+  - sudo cp -r gt-1.5.9-Linux_x86_64-64bit-complete/include/genometools /usr/local/include/
+  - sudo cp -r gt-1.5.9-Linux_x86_64-64bit-complete/lib/* /usr/local/lib/
   - sudo sh -c 'echo "/usr/local/lib" > /etc/ld.so.conf.d/genometools-x86_64.conf'
   - sudo ldconfig
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,11 @@ branches:
 before_install:
   - sudo apt-get update
   - sudo apt-get install -y libcairo2-dev libpango1.0-dev valgrind
-  - wget http://genometools.org/pub/binary_distributions/gt-1.5.9-Linux_x86_64-64bit-complete.tar.gz
-  - tar xzf gt-1.5.9-Linux_x86_64-64bit-complete.tar.gz
-  - sudo cp -r gt-1.5.9-Linux_x86_64-64bit-complete/bin/* /usr/local/bin/
-  - sudo cp -r gt-1.5.9-Linux_x86_64-64bit-complete/include/genometools /usr/local/include/
-  - sudo cp -r gt-1.5.9-Linux_x86_64-64bit-complete/lib/* /usr/local/lib/
+  - wget http://genometools.org/pub/binary_distributions/gt-1.5.10-Linux_x86_64-64bit-complete.tar.gz
+  - tar xzf gt-1.5.10-Linux_x86_64-64bit-complete.tar.gz
+  - sudo cp -r gt-1.5.10-Linux_x86_64-64bit-complete/bin/* /usr/local/bin/
+  - sudo cp -r gt-1.5.10-Linux_x86_64-64bit-complete/include/genometools /usr/local/include/
+  - sudo cp -r gt-1.5.10-Linux_x86_64-64bit-complete/lib/* /usr/local/lib/
   - sudo sh -c 'echo "/usr/local/lib" > /etc/ld.so.conf.d/genometools-x86_64.conf'
   - sudo ldconfig
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ compiler:
   - gcc
 env:
   matrix:
-    - memcheck=yes optimize=yes
-    - memcheck=yes optimize=no
+#    - memcheck=yes optimize=yes
+#    - memcheck=yes optimize=no
     - memcheck=no optimize=yes
     - memcheck=no optimize=no
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ env:
     - memcheck=yes optimize=no
     - memcheck=no optimize=yes
     - memcheck=no optimize=no
+branches:
+  only:  # don't build "pushes" except on the master branch
+    - master
 before_install:
   - sudo apt-get update
   - sudo apt-get install -y libcairo2-dev libpango1.0-dev valgrind

--- a/data/gff3/gaeval-simple.gff3
+++ b/data/gff3/gaeval-simple.gff3
@@ -1,0 +1,31 @@
+##gff-version 3
+##sequence-region   contig1 1 100000
+#
+#      =====----------======-------==----------====
+#
+#        >>>>>>        >>>>>~~~~~~~>>~~~~~~~~~~>>
+#          >>>~~~~~~~~>>>           >~~~~~~~~~~>>>>>
+#
+contig1	nano	gene	61	500	.	+	.	ID=gene1
+contig1	nano	mRNA	61	500	.	+	.	ID=mRNA1;Parent=gene1
+contig1	nano	exon	61	110	.	+	.	Parent=mRNA1
+contig1	nano	CDS	81	110	.	+	0	ID=CDS1;Parent=mRNA1
+contig1	nano	exon	211	270	.	+	.	Parent=mRNA1
+contig1	nano	CDS	211	270	.	+	0	ID=CDS1;Parent=mRNA1
+contig1	nano	exon	341	360	.	+	.	Parent=mRNA1
+contig1	nano	CDS	341	360	.	+	0	ID=CDS1;Parent=mRNA1
+contig1	nano	CDS	461	479	.	+	1	ID=CDS1;Parent=mRNA1
+contig1	nano	exon	461	500	.	+	.	Parent=mRNA1
+###
+contig1	nano	cDNA_match	81	140	.	+	.	ID=cDNA_match1
+###
+contig1	nano	cDNA_match	101	130	.	+	.	ID=cDNA_match2
+contig1	nano	cDNA_match	211	240	.	+	.	ID=cDNA_match2
+###
+contig1	nano	cDNA_match	221	270	.	+	.	ID=cDNA_match3
+contig1	nano	cDNA_match	341	360	.	+	.	ID=cDNA_match3
+contig1	nano	cDNA_match	461	480	.	+	.	ID=cDNA_match3
+###
+contig1	nano	cDNA_match	351	360	.	+	.	ID=cDNA_match4
+contig1	nano	cDNA_match	461	510	.	+	.	ID=cDNA_match4
+###

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -295,6 +295,10 @@ Class AgnGaevalVisitor
 
   Class constructor for the node visitor.
 
+.. c:function:: void agn_gaeval_visitor_tsv_out(AgnGaevalVisitor *v, GtStr *tsvfilename)
+
+  Indicate a file to be used for printing TSV output.
+
 .. c:function:: bool agn_gaeval_visitor_unit_test(AgnUnitTest *test)
 
   Run unit tests for this class.

--- a/inc/core/AgnGaevalVisitor.h
+++ b/inc/core/AgnGaevalVisitor.h
@@ -52,6 +52,11 @@ GtNodeVisitor*
 agn_gaeval_visitor_new(GtNodeStream *astream, AgnGaevalParams gparams);
 
 /**
+* @function Indicate a file to be used for printing TSV output.
+*/
+void agn_gaeval_visitor_tsv_out(AgnGaevalVisitor *v, GtStr *tsvfilename);
+
+/**
  * @function Run unit tests for this class.
  */
 bool agn_gaeval_visitor_unit_test(AgnUnitTest *test);

--- a/src/core/AgnInferCDSVisitor.c
+++ b/src/core/AgnInferCDSVisitor.c
@@ -427,7 +427,7 @@ static void infer_cds_visitor_free(GtNodeVisitor *nv)
 
 static void infer_cds_visitor_infer_cds(AgnInferCDSVisitor *v)
 {
-  GtFeatureNode **start_codon, **stop_codon;
+  GtFeatureNode **start_codon = NULL, **stop_codon = NULL;
 
   bool exonsexplicit    = gt_array_size(v->exons) > 0;
   bool startcodon_check = gt_array_size(v->starts) == 1 &&

--- a/src/gaeval.c
+++ b/src/gaeval.c
@@ -147,12 +147,12 @@ int main(int argc, char **argv)
   GtNodeStream *stream, *last_stream, *align_stream;
   GtQueue *streams;
   GaevalOptions options;
-  parse_options(argc, argv, &options);
 
   //----------
   // Set up the processing stream
   //----------
   gt_lib_init();
+  parse_options(argc, argv, &options);
   streams = gt_queue_new();
 
   stream = gt_gff3_in_stream_new_unsorted(1, &options.alignfile);
@@ -179,7 +179,12 @@ int main(int argc, char **argv)
   last_stream = stream;
   gt_str_delete(source);
 
-  stream = agn_gaeval_stream_new(last_stream, align_stream, options.params);
+  GtNodeVisitor *nv = agn_gaeval_visitor_new(align_stream, options.params);
+  if(options.tsvout)
+  {
+    agn_gaeval_visitor_tsv_out((AgnGaevalVisitor *)nv, options.tsvout);
+  }
+  stream = gt_visitor_stream_new(last_stream, nv);
   gt_queue_add(streams, stream);
   last_stream = stream;
 

--- a/src/gaeval.c
+++ b/src/gaeval.c
@@ -21,6 +21,7 @@ typedef struct
   const char *alignfile;
   const char **genefiles;
   int numgenefiles;
+  GtStr *tsvout;
   AgnGaevalParams params;
 } GaevalOptions;
 
@@ -43,7 +44,9 @@ static void print_usage(FILE *outstream)
 "Usage: gaeval [options] alignments.gff3 genes.gff3 [moregenes.gff3 ...]\n"
 "  Basic options:\n"
 "    -h|--help               print this help message and exit\n"
-"    -v|--version            print version number and exit\n\n"
+"    -v|--version            print version number and exit\n"
+"    -t|--tsv FILE           print coverage and integrity scores to the\n"
+"                            specified file in tab-separated text\n\n"
 "  Weights for calculating integrity score (must add up to 1.0):\n"
 "    -a|--alpha: DOUBLE      introns confirmed, or %% expected CDS length for\n"
 "                            single-exon genes; default is 0.6\n"
@@ -58,14 +61,16 @@ static void print_usage(FILE *outstream)
 
 static void parse_options(int argc, char **argv, GaevalOptions *options)
 {
+  options->tsvout = NULL;
   default_params(&options->params);
   int opt = 0;
   int optindex = 0;
-  const char *optstr = "hva:b:g:e:c:5:3:";
+  const char *optstr = "hvt:a:b:g:e:c:5:3:";
   const struct option gaeval_options[] =
   {
     { "help",      no_argument,       NULL, 'h' },
     { "version",   no_argument,       NULL, 'v' },
+    { "tsv",       required_argument, NULL, 't' },
     { "alpha",     required_argument, NULL, 'a' },
     { "beta",      required_argument, NULL, 'b' },
     { "gamma",     required_argument, NULL, 'g' },
@@ -98,6 +103,14 @@ static void parse_options(int argc, char **argv, GaevalOptions *options)
     }
     else if(opt == 'g')
       options->params.gamma = atof(optarg);
+    else if(opt == 't')
+    {
+      if(options->tsvout != NULL)
+      {
+        gt_str_delete(options->tsvout);
+      }
+      options->tsvout = gt_str_new_cstr(optarg);
+    }
     else if(opt == 'v')
     {
       agn_print_version("GAEVAL", stdout);


### PR DESCRIPTION
**NOTE: This pull request is a work in progress and is not yet ready to be merged.**

This PR adds an option to the `gaeval` program to write coverage and integrity scores to a tab delimited text file, in addition to adding `gaeval_coverage` and `gaeval_integrity` attributes to the mRNA features in the GFF3 output. This makes the data more accessible for loading into R, Python, and similar analysis environments.

We should include:
- [x] the individual components of the integrity score
- [x] number of introns (any other features that would help in interpreting the score?)
- [x] automated test(s) to satisfy minimally responsible level of software development
