### PR TITLE
Fix handling of pseudogenic transcript annotations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,11 @@ env:
 before_install:
   - sudo apt-get update
   - sudo apt-get install -y libcairo2-dev libpango1.0-dev valgrind
-  - wget http://genometools.org/pub/binary_distributions/gt-1.5.8-Linux_x86_64-64bit-complete.tar.gz
-  - tar xzf gt-1.5.8-Linux_x86_64-64bit-complete.tar.gz
-  - sudo cp -r gt-1.5.8-Linux_x86_64-64bit-complete/bin/* /usr/local/bin/
-  - sudo cp -r gt-1.5.8-Linux_x86_64-64bit-complete/include/genometools /usr/local/include/
-  - sudo cp -r gt-1.5.8-Linux_x86_64-64bit-complete/lib/* /usr/local/lib/
+  - wget http://genometools.org/pub/binary_distributions/gt-1.5.9-Linux_x86_64-64bit-complete.tar.gz
+  - tar xzf gt-1.5.9-Linux_x86_64-64bit-complete.tar.gz
+  - sudo cp -r gt-1.5.9-Linux_x86_64-64bit-complete/bin/* /usr/local/bin/
+  - sudo cp -r gt-1.5.9-Linux_x86_64-64bit-complete/include/genometools /usr/local/include/
+  - sudo cp -r gt-1.5.9-Linux_x86_64-64bit-complete/lib/* /usr/local/lib/
   - sudo sh -c 'echo "/usr/local/lib" > /etc/ld.so.conf.d/genometools-x86_64.conf'
   - sudo ldconfig
 addons:

--- a/src/core/AgnPseudogeneFixVisitor.c
+++ b/src/core/AgnPseudogeneFixVisitor.c
@@ -220,8 +220,11 @@ visit_feature_node(GtNodeVisitor *nv, GtFeatureNode *fn, GtError *error)
           subfeat != NULL;
           subfeat  = gt_feature_node_iterator_next(subiter))
       {
-        if(gt_feature_node_has_type(subfeat, "transcript"))
+        if(gt_feature_node_has_type(subfeat, "transcript") ||
+           gt_feature_node_has_type(subfeat, "mRNA"))
+        {
           gt_feature_node_set_type(subfeat, "pseudogenic_transcript");
+        }
         else if(gt_feature_node_has_type(subfeat, "exon"))
           gt_feature_node_set_type(subfeat, "pseudogenic_exon");
       }


### PR DESCRIPTION
NCBI's GFF3 encoding of pseudogenes has long confused me. Instead of using the perfectly SO-compliant terms `pseudogene` and `pseudogenic_exon`, they instead use the canonical terms `gene` and `exon` and simply declare `pseudo=true` in the attributes. This places an additional (undisclosed!) burden on the user to distinguish between protein-coding genes and pseudogenes.

A while ago I built fixes for this into the AEGeAn programs. Features of type `gene` with the attribute `pseudo=true`, as well as any corresponding `transcript` or `exon` children, are re-typed as `pseudogene`, `pseudogenic_transcript`, and `pseudogenic_exon`, respectively.

Recent updates to GenHub have revealed that some NCBI GFF3 files now use the type `mRNA` to refer to pseudogenic transcripts. **This pull request extends the code to handle these cases**.