### PR TITLE
Support --idfile flag in xtractore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ compiler:
   - clang
   - gcc
 env:
-  global:
-    - secure: dvoqjqYCjvOs6m6bcqW9hIxq8ZzgkA21SwPFm+PP1tRdMo7gspfhjDHceEBKHTxe75e6m1d7fEQjfrmtqMRruFP9qLgDvFdmwX5jSKrj45vjq1DYc+6RNdxXCBdOEQhlf2VVNWGzJ3j+NplHhzob8dHM8G6jNzz3YVpW+7e6pKM=
   matrix:
     - memcheck=yes optimize=yes
     - memcheck=yes optimize=no
@@ -20,15 +18,6 @@ before_install:
   - sudo cp -r gt-1.5.9-Linux_x86_64-64bit-complete/lib/* /usr/local/lib/
   - sudo sh -c 'echo "/usr/local/lib" > /etc/ld.so.conf.d/genometools-x86_64.conf'
   - sudo ldconfig
-addons:
-  coverity_scan:
-    project:
-      name: standage/AEGeAn
-      description: Build submitted via Travis CI
-    notification_email: daniel.standage@gmail.com
-    build_command_prepend: make clean
-    build_command: make test
-    branch_pattern: covscan
 install:
   - sudo make install
   - sudo ldconfig

--- a/data/gff3/bogus-three-genes.gff3
+++ b/data/gff3/bogus-three-genes.gff3
@@ -1,0 +1,5 @@
+##gff-version        3
+##sequence-region contig42 1 525600
+contig42	nano	gene	10000	14233	.	+	.	ID=gene1
+contig42	nano	gene	56053	61117	.	+	.	ID=gene2
+contig42	nano	gene	220074	224888	.	-	.	ID=gene3

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -323,11 +323,11 @@ Class AgnIdFilterStream
 
 .. c:type:: AgnIdFilterStream
 
-  Implements the GenomeTools ``GtNodeStream`` interface. This is a node stream used to select features from a pre-specified list of IDs from a node stream. See the `AgnIdFilterStream class header <https://github.com/standage/AEGeAn/blob/master/inc/core/AgnIdFilterStream.h>`_.
+  Implements the GenomeTools ``GtNodeStream`` interface. This is a node stream used to select features from a node stream using a pre-specified list of IDs. See the `AgnIdFilterStream class header <https://github.com/standage/AEGeAn/blob/master/inc/core/AgnIdFilterStream.h>`_.
 
 .. c:function:: GtNodeStream* agn_id_filter_stream_new(GtNodeStream *in_stream, GtHashmap *ids2keep)
 
-  Class constructor. The keys of the ``typestokeep`` hashmap should be the type(s) to be kept from the node stream. Any non-NULL value can be associated with those keys.
+  Class constructor. The keys of the ``ids2keep`` hashmap should be strings of the IDs of features to be kept from the node stream. Any non-NULL value can be associated with those keys.
 
 .. c:function:: bool agn_id_filter_stream_unit_test(AgnUnitTest *test)
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -318,6 +318,21 @@ Class AgnGeneStream
 
   Run unit tests for this class. Returns true if all tests passed.
 
+Class AgnIdFilterStream
+-----------------------
+
+.. c:type:: AgnIdFilterStream
+
+  Implements the GenomeTools ``GtNodeStream`` interface. This is a node stream used to select features from a pre-specified list of IDs from a node stream. See the `AgnIdFilterStream class header <https://github.com/standage/AEGeAn/blob/master/inc/core/AgnIdFilterStream.h>`_.
+
+.. c:function:: GtNodeStream* agn_id_filter_stream_new(GtNodeStream *in_stream, GtHashmap *ids2keep)
+
+  Class constructor. The keys of the ``typestokeep`` hashmap should be the type(s) to be kept from the node stream. Any non-NULL value can be associated with those keys.
+
+.. c:function:: bool agn_id_filter_stream_unit_test(AgnUnitTest *test)
+
+  Run unit tests for this class. Returns true if all tests passed.
+
 Class AgnInferCDSVisitor
 ------------------------
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -11,9 +11,9 @@ For the impatient
     sudo apt-get install -y build-essential git libcairo2-dev libpango1.0-dev
 
     # Download, compile, and install the GenomeTools package
-    curl -O http://genometools.org/pub/genometools-1.5.8.tar.gz
-    tar xzf genometools-1.5.8.tar.gz
-    cd genometools-1.5.8
+    curl -O http://genometools.org/pub/genometools-1.5.9.tar.gz
+    tar xzf genometools-1.5.9.tar.gz
+    cd genometools-1.5.9
     make
     sudo make install
     cd ..

--- a/inc/core/AgnIdFilterStream.h
+++ b/inc/core/AgnIdFilterStream.h
@@ -18,14 +18,14 @@ online at https://github.com/standage/AEGeAn/blob/master/LICENSE.
  * @class AgnIdFilterStream
  *
  * Implements the GenomeTools ``GtNodeStream`` interface. This is a node stream
- * used to select features from a pre-specified list of IDs from a node stream.
+ * used to select features from a node stream using a pre-specified list of IDs.
  */
 typedef struct AgnIdFilterStream AgnIdFilterStream;
 
 /**
- * @function Class constructor. The keys of the ``typestokeep`` hashmap should
- * be the type(s) to be kept from the node stream. Any non-NULL value can be
- * associated with those keys.
+ * @function Class constructor. The keys of the ``ids2keep`` hashmap should
+ * be strings of the IDs of features to be kept from the node stream. Any
+ * non-NULL value can be associated with those keys.
  */
 GtNodeStream* agn_id_filter_stream_new(GtNodeStream *in_stream,
                                        GtHashmap *ids2keep);

--- a/inc/core/AgnIdFilterStream.h
+++ b/inc/core/AgnIdFilterStream.h
@@ -1,0 +1,38 @@
+/**
+
+Copyright (c) 2017, Daniel S. Standage and CONTRIBUTORS
+
+The AEGeAn Toolkit is distributed under the ISC License. See
+the 'LICENSE' file in the AEGeAn source code distribution or
+online at https://github.com/standage/AEGeAn/blob/master/LICENSE.
+
+**/
+#ifndef AEGEAN_ID_FILTER_STREAM
+#define AEGEAN_ID_FILTER_STREAM
+
+#include "extended/node_stream_api.h"
+#include "core/hashmap_api.h"
+#include "AgnUnitTest.h"
+
+/**
+ * @class AgnIdFilterStream
+ *
+ * Implements the GenomeTools ``GtNodeStream`` interface. This is a node stream
+ * used to select features from a pre-specified list of IDs from a node stream.
+ */
+typedef struct AgnIdFilterStream AgnIdFilterStream;
+
+/**
+ * @function Class constructor. The keys of the ``typestokeep`` hashmap should
+ * be the type(s) to be kept from the node stream. Any non-NULL value can be
+ * associated with those keys.
+ */
+GtNodeStream* agn_id_filter_stream_new(GtNodeStream *in_stream,
+                                       GtHashmap *ids2keep);
+
+/**
+ * @function Run unit tests for this class. Returns true if all tests passed.
+ */
+bool agn_id_filter_stream_unit_test(AgnUnitTest *test);
+
+#endif

--- a/inc/core/aegean.h
+++ b/inc/core/aegean.h
@@ -15,6 +15,7 @@ online at https://github.com/standage/AEGeAn/blob/master/LICENSE.
 #include "AgnComparison.h"
 #include "AgnFilterStream.h"
 #include "AgnGeneStream.h"
+#include "AgnIdFilterStream.h"
 #include "AgnInferCDSVisitor.h"
 #include "AgnInferExonsVisitor.h"
 #include "AgnInferParentStream.h"

--- a/src/core/AgnIdFilterStream.c
+++ b/src/core/AgnIdFilterStream.c
@@ -168,6 +168,7 @@ bool agn_id_filter_stream_unit_test(AgnUnitTest *test)
     gt_node_stream_delete(ifs);
     gt_node_stream_delete(aos);
     gt_error_delete(error);
+    gt_queue_delete(queue);
 
     return agn_unit_test_success(test);
 }

--- a/src/core/AgnIdFilterStream.c
+++ b/src/core/AgnIdFilterStream.c
@@ -123,7 +123,7 @@ static int id_filter_stream_next(GtNodeStream *ns, GtGenomeNode **gn,
     }
     else
     {
-      // gt_genome_node_delete(*gn);
+      gt_genome_node_delete(*gn);
       continue;
     }
   }
@@ -167,6 +167,7 @@ bool agn_id_filter_stream_unit_test(AgnUnitTest *test)
     gt_node_stream_delete(ais);
     gt_node_stream_delete(ifs);
     gt_node_stream_delete(aos);
+    gt_error_delete(error);
 
     return agn_unit_test_success(test);
 }

--- a/src/core/AgnIdFilterStream.c
+++ b/src/core/AgnIdFilterStream.c
@@ -1,0 +1,194 @@
+/**
+
+Copyright (c) 2017, Daniel S. Standage and CONTRIBUTORS
+
+The AEGeAn Toolkit is distributed under the ISC License. See
+the 'LICENSE' file in the AEGeAn source code distribution or
+online at https://github.com/standage/AEGeAn/blob/master/LICENSE.
+
+**/
+
+#include <string.h>
+#include "core/queue_api.h"
+#include "extended/array_in_stream_api.h"
+#include "extended/array_out_stream_api.h"
+#include "extended/feature_node_iterator_api.h"
+#include "AgnIdFilterStream.h"
+#include "AgnTypecheck.h"
+#include "AgnUtils.h"
+
+//------------------------------------------------------------------------------
+// Data structure definition
+//------------------------------------------------------------------------------
+
+struct AgnIdFilterStream
+{
+  const GtNodeStream parent_instance;
+  GtNodeStream *in_stream;
+  GtHashmap *ids2keep;
+};
+
+
+//------------------------------------------------------------------------------
+// Prototypes for private functions
+//------------------------------------------------------------------------------
+
+#define id_filter_stream_cast(GS)\
+        gt_node_stream_cast(id_filter_stream_class(), GS)
+
+/**
+ * @function Implements the GtNodeStream interface for this class.
+ */
+static const GtNodeStreamClass* id_filter_stream_class(void);
+
+/**
+ * @function Class destructor.
+ */
+static void id_filter_stream_free(GtNodeStream *ns);
+
+/**
+ * @function Pulls nodes from the input stream and feeds them to the output
+ * stream if they are in the list of IDs to keep.
+ */
+static int id_filter_stream_next(GtNodeStream *ns, GtGenomeNode **gn,
+                                GtError *error);
+
+/**
+ * @function Generate data for unit testing.
+ */
+static void id_filter_stream_test_data(GtQueue *queue);
+
+
+//------------------------------------------------------------------------------
+// Method implementations
+//------------------------------------------------------------------------------
+
+GtNodeStream* agn_id_filter_stream_new(GtNodeStream *in_stream,
+                                       GtHashmap *ids2keep)
+{
+  GtNodeStream *ns;
+  AgnIdFilterStream *stream;
+  agn_assert(in_stream && ids2keep);
+  ns = gt_node_stream_create(id_filter_stream_class(), false);
+  stream = id_filter_stream_cast(ns);
+  stream->in_stream = gt_node_stream_ref(in_stream);
+  stream->ids2keep = gt_hashmap_ref(ids2keep);
+  return ns;
+}
+
+static const GtNodeStreamClass *id_filter_stream_class(void)
+{
+  static const GtNodeStreamClass *nsc = NULL;
+  if(!nsc)
+  {
+    nsc = gt_node_stream_class_new(sizeof (AgnIdFilterStream),
+                                   id_filter_stream_free,
+                                   id_filter_stream_next);
+  }
+  return nsc;
+}
+
+static void id_filter_stream_free(GtNodeStream *ns)
+{
+  AgnIdFilterStream *stream = id_filter_stream_cast(ns);
+  gt_node_stream_delete(stream->in_stream);
+  gt_hashmap_delete(stream->ids2keep);
+}
+
+static int id_filter_stream_next(GtNodeStream *ns, GtGenomeNode **gn,
+                                 GtError *error)
+{
+  AgnIdFilterStream *stream;
+  GtFeatureNode *fn;
+  int had_err;
+  gt_error_check(error);
+  stream = id_filter_stream_cast(ns);
+
+  while(1)
+  {
+    had_err = gt_node_stream_next(stream->in_stream, gn, error);
+    if(had_err)
+      return had_err;
+    if(!*gn)
+      return 0;
+
+    fn = gt_feature_node_try_cast(*gn);
+    if(!fn)
+      return 0;
+
+    const char *featureid = gt_feature_node_get_attribute(fn, "ID");
+    if(gt_hashmap_get(stream->ids2keep, featureid) != NULL)
+    {
+      return 0;
+    }
+    else
+    {
+      // gt_genome_node_delete(*gn);
+      continue;
+    }
+  }
+
+  // *gn = NULL;
+  return 0;
+}
+
+bool agn_id_filter_stream_unit_test(AgnUnitTest *test)
+{
+    GtArray *source, *sink;
+    GtHashmap *ids;
+    GtNodeStream *aos, *ais, *ifs;
+    GtUword progress;
+
+    GtError *error = gt_error_new();
+    GtQueue *queue = gt_queue_new();
+    id_filter_stream_test_data(queue);
+    agn_assert(gt_queue_size(queue) == 1);
+
+    source = gt_queue_get(queue);
+    sink = gt_array_new( sizeof(GtFeatureNode *) );
+    ids = gt_hashmap_new(GT_HASH_STRING, NULL, NULL);
+    gt_hashmap_add(ids, "gene2", "gene2");
+    ais = gt_array_in_stream_new(source, &progress, error);
+    ifs = agn_id_filter_stream_new(ais, ids);
+    aos = gt_array_out_stream_new(ifs, sink, error);
+    gt_node_stream_pull(aos, error);
+    bool test1 = gt_array_size(sink) == 1;
+    if(test1)
+    {
+      GtFeatureNode *fn = *(GtFeatureNode **)gt_array_pop(sink);
+      const char *featureid = gt_feature_node_get_attribute(fn, "ID");
+      test1 = featureid != NULL && strcmp(featureid, "gene2") == 0;
+      gt_genome_node_delete((GtGenomeNode *)fn);
+    }
+    agn_unit_test_result(test, "gene2", test1);
+    gt_array_delete(source);
+    gt_array_delete(sink);
+    gt_hashmap_delete(ids);
+    gt_node_stream_delete(ais);
+    gt_node_stream_delete(ifs);
+    gt_node_stream_delete(aos);
+
+    return agn_unit_test_success(test);
+}
+
+static void id_filter_stream_test_data(GtQueue *queue)
+{
+  GtError *error = gt_error_new();
+  const char *refrfile = "data/gff3/bogus-three-genes.gff3";
+  GtNodeStream *gff3in = gt_gff3_in_stream_new_unsorted(1, &refrfile);
+  gt_gff3_in_stream_check_id_attributes((GtGFF3InStream *)gff3in);
+  gt_gff3_in_stream_enable_tidy_mode((GtGFF3InStream *)gff3in);
+  GtArray *feats = gt_array_new( sizeof(GtFeatureNode *) );
+  GtNodeStream *arraystream = gt_array_out_stream_new(gff3in, feats, error);
+  int pullresult = gt_node_stream_pull(arraystream, error);
+  if(pullresult == -1)
+  {
+    fprintf(stderr, "[AgnFilterStream::id_filter_stream_test_data] error "
+            "processing features: %s\n", gt_error_get(error));
+  }
+  gt_node_stream_delete(gff3in);
+  gt_node_stream_delete(arraystream);
+  gt_queue_add(queue, feats);
+
+  gt_error_delete(error);
+}

--- a/test/unittests.c
+++ b/test/unittests.c
@@ -13,6 +13,7 @@ online at https://github.com/standage/AEGeAn/blob/master/LICENSE.
 #include "AgnFilterStream.h"
 #include "AgnGaevalVisitor.h"
 #include "AgnGeneStream.h"
+#include "AgnIdFilterStream.h"
 #include "AgnInferCDSVisitor.h"
 #include "AgnInferExonsVisitor.h"
 #include "AgnInferParentStream.h"
@@ -60,6 +61,8 @@ int main(int argc, char **argv)
                                         agn_locus_refine_stream_unit_test));
   gt_queue_add(tests, agn_unit_test_new("AEGeAn::AgnGaevalVisitor",
                                         agn_gaeval_visitor_unit_test));
+  gt_queue_add(tests, agn_unit_test_new("AEGeAn::AgnIdFilterStream",
+                                        agn_id_filter_stream_unit_test));
 
   unsigned passes   = 0;
   unsigned failures = 0;


### PR DESCRIPTION
Issue #183 exposed that the `--idfile` option of `xtractore` was aspirational scaffolding (misleading to the interested user) and not a functioning feature. This pull request implements the advertised functionality, introducing the `AgnIdFilterStream` class to handle the core processing.

Closes #183.