### PR TITLE
Check and fix children of pseudogene features

### DIFF
--- a/src/core/AgnPseudogeneFixVisitor.c
+++ b/src/core/AgnPseudogeneFixVisitor.c
@@ -208,7 +208,7 @@ visit_feature_node(GtNodeVisitor *nv, GtFeatureNode *fn, GtError *error)
       current != NULL;
       current  = gt_feature_node_iterator_next(iter))
   {
-    if(!agn_typecheck_gene(current))
+    if(!agn_typecheck_gene(current) && !agn_typecheck_pseudogene(current))
       continue;
 
     const char *attrvalue = gt_feature_node_get_attribute(current, "pseudo");


### PR DESCRIPTION
NCBI GFF3 conventions used to label pseudogenes as `gene` features, with a `pseudo=true` attribute to distinguish between protein-coding genes and other gene types vs pseudogenes. The `fixgff3` program was created in part to correct these cases, changing the feature type from `gene` to `pseudogene` and the types of the children from `transcript` and `exon` to `pseudogenic_transcript` and `pseudogenic_exon`, and so on.

It appears NCBI has made some progress recently. Psuedogenes are now labeled correctly with the `pseudogene` type, although transcripts and exons appear that they have not been relabeled. This pull request updates the `fixgff3` program to correct children of pseudogenes, regardless of whether they are labeled with the `gene` type or the `pseudogene` type.