### PR TITLE
Include orientation of flanking genes with iiLocus lengths 

### DIFF
--- a/data/gff3/zitest-01.gff3
+++ b/data/gff3/zitest-01.gff3
@@ -1,0 +1,21 @@
+##gff-version 3
+##sequence-region   seq1 1 9400
+# ============================================================================ #
+#        ------>             ------>              <------ ------>              #
+# ============================================================================ #
+seq1	nano	gene	1001	2000	.	+	.	ID=g1
+seq1	nano	mRNA	1001	2000	.	+	.	ID=t1;Parent=g1
+seq1	nano	CDS	1001	2000	.	+	0	Parent=t1
+###
+seq1	nano	gene	4001	5000	.	+	.	ID=g2
+seq1	nano	mRNA	4001	5000	.	+	.	ID=t2;Parent=g2
+seq1	nano	CDS	4001	5000	.	+	0	Parent=t2
+###
+seq1	nano	gene	7001	8000	.	-	.	ID=g3
+seq1	nano	mRNA	7001	8000	.	-	.	ID=t3;Parent=g3
+seq1	nano	CDS	7001	8000	.	-	0	Parent=t3
+###
+seq1	nano	gene	8151	9400	.	+	.	ID=g4
+seq1	nano	mRNA	8151	9400	.	+	.	ID=t4;Parent=g4
+seq1	nano	CDS	8151	9400	.	+	0	Parent=t4
+###

--- a/data/gff3/zitest-02.gff3
+++ b/data/gff3/zitest-02.gff3
@@ -1,0 +1,21 @@
+##gff-version 3
+##sequence-region   seq2 1 11000
+# ============================================================================ #
+#        ------> <-----------        <------              <------              #
+# ============================================================================ #
+seq2	nano	gene	1001	2000	.	+	.	ID=g1
+seq2	nano	mRNA	1001	2000	.	+	.	ID=t1;Parent=g1
+seq2	nano	CDS	1001	2000	.	+	0	Parent=t1
+###
+seq2	nano	gene	2101	5000	.	-	.	ID=g2
+seq2	nano	mRNA	2101	5000	.	-	.	ID=t2;Parent=g2
+seq2	nano	CDS	2101	5000	.	-	0	Parent=t2
+###
+seq2	nano	gene	7001	8000	.	-	.	ID=g3
+seq2	nano	mRNA	7001	8000	.	-	.	ID=t3;Parent=g3
+seq2	nano	CDS	7001	8000	.	-	0	Parent=t3
+###
+seq2	nano	gene	10001	11000	.	-	.	ID=g4
+seq2	nano	mRNA	10001	11000	.	-	.	ID=t4;Parent=g4
+seq2	nano	CDS	10001	11000	.	-	0	Parent=t4
+###

--- a/data/gff3/zitest-03.gff3
+++ b/data/gff3/zitest-03.gff3
@@ -1,0 +1,26 @@
+##gff-version 3
+##sequence-region   seq3 1 10000
+# ============================================================================ #
+#       -------> ------------------------->             ------>                #
+#                        -->          <--                                      #
+# ============================================================================ #
+seq3	nano	gene	1001	2000	.	+	.	ID=g1
+seq3	nano	mRNA	1001	2000	.	+	.	ID=t1;Parent=g1
+seq3	nano	CDS	1001	2000	.	+	0	Parent=t1
+###
+seq3	nano	gene	2101	7000	.	+	.	ID=g2
+seq3	nano	mRNA	2101	7000	.	+	.	ID=t2;Parent=g2
+seq3	nano	CDS	2101	7000	.	+	0	Parent=t2
+###
+seq3	nano	gene	3001	3500	.	+	.	ID=g3
+seq3	nano	mRNA	3001	3500	.	+	.	ID=t3;Parent=g3
+seq3	nano	CDS	3001	3500	.	+	0	Parent=t3
+###
+seq3	nano	gene	5501	6000	.	-	.	ID=g4
+seq3	nano	mRNA	5501	6000	.	-	.	ID=t4;Parent=g4
+seq3	nano	CDS	5501	6000	.	-	0	Parent=t4
+###
+seq3	nano	gene	9001	10000	.	+	.	ID=g5
+seq3	nano	mRNA	9001	10000	.	+	.	ID=t5;Parent=g5
+seq3	nano	CDS	9001	10000	.	+	0	Parent=t5
+###

--- a/data/misc/amel-ogs-ilens.txt
+++ b/data/misc/amel-ogs-ilens.txt
@@ -1,9 +1,9 @@
-Group7.16	21570
-Group7.16	916
-Group7.16	2246
-Group7.16	8490
-Group7.16	314
-Group7.16	0
-Group7.16	0
-Group7.16	0
-Group7.16	467
+Group7.16	21570	FF
+Group7.16	916	FF
+Group7.16	2246	FR
+Group7.16	8490	RF
+Group7.16	0	NA
+Group7.16	314	FF
+Group7.16	0	FR
+Group7.16	0	RR
+Group7.16	467	RR

--- a/data/misc/zitest-01-ilens.tsv
+++ b/data/misc/zitest-01-ilens.tsv
@@ -1,0 +1,3 @@
+seq1	1000	FF
+seq1	1000	FR
+seq1	0	RF

--- a/data/misc/zitest-02-ilens.tsv
+++ b/data/misc/zitest-02-ilens.tsv
@@ -1,0 +1,3 @@
+seq2	0	FR
+seq2	1000	RR
+seq2	1000	RR

--- a/data/misc/zitest-03-ilens.tsv
+++ b/data/misc/zitest-03-ilens.tsv
@@ -1,0 +1,4 @@
+seq3	1000	FR
+seq3	0	NA
+seq3	0	NA
+seq3	2000	RF

--- a/data/misc/zitest-03-ilens.tsv
+++ b/data/misc/zitest-03-ilens.tsv
@@ -1,4 +1,4 @@
-seq3	1000	FR
+seq3	0	FF
 seq3	0	NA
 seq3	0	NA
-seq3	2000	RF
+seq3	1000	FF

--- a/test/iLocusParsing.sh
+++ b/test/iLocusParsing.sh
@@ -20,12 +20,12 @@ run_func_test()
     echo "Error running functional test '$testlabel'"
     exit 1
   fi
-  
+
   set +e
   diff $tempfile $testoutfile > /dev/null 2>&1
   status=$?
   set -e
-  
+
   result="FAIL"
   if [ $status == 0 ]; then
     result="PASS"
@@ -48,5 +48,9 @@ run_func_test "Megachile rotundata CST (intron)" data/gff3/mrot-cst-out-cds.gff3
 run_func_test "iiLocus lengths (Amel OGS Group7.16)" data/misc/amel-ogs-ilens.txt --delta=300 --ilens=${tempfile} --cds data/gff3/amel-ogs-g716.gff3
 run_func_test "Nasonia vitripennis (intron gene)" data/gff3/nvit-exospindle-out.gff3 --outfile=${tempfile} --cds data/gff3/nvit-exospindle.gff3
 run_func_test "A. echinatior (intron gene + ncRNA)" data/gff3/aech-dachsous-out.gff3 --outfile=${tempfile} --cds data/gff3/aech-dachsous.gff3
+run_func_test "iiLocus Flank Orientations (test 1)" data/misc/zitest-01-ilens.tsv --ilens=${tempfile} --cds data/gff3/zitest-01.gff3
+run_func_test "iiLocus Flank Orientations (test 2)" data/misc/zitest-02-ilens.tsv --ilens=${tempfile} --cds data/gff3/zitest-02.gff3
+run_func_test "iiLocus Flank Orientations (test 3)" data/misc/zitest-03-ilens.tsv --ilens=${tempfile} --cds data/gff3/zitest-03.gff3
+
 
 exit $failures


### PR DESCRIPTION
Currently, ziLoci are not included in any GFF3 output, but their presence is recorded along with all other iiLoci in an ancillary "iiLocus lengths" file output by `locuspocus`. This pull request will integrate information related to flanking genes into this ancillary file.

This PR is a in progress. The first commit has only test data: input GFF3 files for 3 tests, and the desired contents of the "iiLocus lengths" file to be produced. Subsequent commits will implement the code the produce the desired output.