### PR TITLE
follow symlinks when copying data

### DIFF
--- a/src/ParsEval/pe_options.c
+++ b/src/ParsEval/pe_options.c
@@ -262,7 +262,7 @@ int pe_parse_options(int argc, char **argv, ParsEvalOptions *options,
     }
 
     char copy_cmd[1024];
-    sprintf(copy_cmd,"cp -r %s/* %s", options->data_path, options->outfilename);
+    sprintf(copy_cmd,"cp -LR %s/* %s", options->data_path, options->outfilename);
     if(options->debug)
       fprintf(stderr, "debug: copying shared data: '%s'\n", copy_cmd);
     if(system(copy_cmd) != 0)


### PR DESCRIPTION
In some situations, relative symlinks might be copied verbatim from the data path, breaking links in the HTML output. This PR makes sure symlinks are followed when copying, using the actual files.
This change tries to adhere to POSIX's `cp` parameters (http://pubs.opengroup.org/onlinepubs/9699919799/utilities/cp.html), using `-L` and `-R` instead of GNU's  `-r`.