### PR TITLE
Filtered badly defined gene parent

### DIFF
--- a/fidibus/fidibus/genomes/Dmel.yml
+++ b/fidibus/fidibus/genomes/Dmel.yml
@@ -9,6 +9,7 @@ Dmel:
     annotfilter:
         - NC_024511.2
         - exception=trans-splicing
+        - Dmel_CG32491
     seqfilter:
         - NC_024511.2
     checksums:


### PR DESCRIPTION
Error in GFF file downloaded from NCBI: "gene-Dmel_CG32491" is not properly defined causing fidibus prep to break. 