### PR TITLE
Update docs, README, and branding

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -28,7 +28,7 @@ For a gentle introduction to singularity, see our group
 AEGeAn use via the singularity container is highly recommended, with no known
 drawbacks.
 However, if desired, you can of course install all the required third party
-software and our _fidibus_ python package individually on your computer system.
+software and our _fidibus_ Python package individually on your computer system.
 The singularity [recipe file](./Singularity) in this repository should serve as
 a guide to perform such an installation.
 The `aegean.simg` container was built on the 

--- a/README.md
+++ b/README.md
@@ -1,25 +1,36 @@
-# AEGeAn Toolkit
+# AEGeAn Toolkit: analysis and evaluation of genome annotations
 
-AEGeAn: <b>a</b>nalysis and <b>e</b>valuation of <b>ge</b>nome <b>an</b>notations
+[![AEGeAn build status](https://api.travis-ci.org/BrendelGroup/AEGeAn.svg?branch=master)](https://travis-ci.org/BrendelGroup/AEGeAn)
+[![ReadTheDocs build status](https://readthedocs.org/projects/aegean/badge/?version=latest)](https://readthedocs.org/projects/aegean/badge/?version=latest)
 
-The AEGeAn Toolkit provides a bundle of tools for managing and analyzing whole-genome gene structure annotations.
+The AEGeAn Toolkit provides a bundle of software tools for evaluating gene structure annotations and genome organization.
+The **LocusPocus** program is designed a break down an annotated eukaryotic genome into its constituent parts, and the **fidibus** workflow brings in a variety of other programs and scripts to summarize genome content and the spacing genes.
+The code conforms to our [RAMOSE](https://brendelgroup.github.io/) philosophy: it generates **reproducible**, **accurate**, and **meaningful** results; it is **open** (source) and designed to be **scalable** and **easy** to use.
+
 
 ## Installation
-Please find detailed installation instructions and options in the
-[INSTALL](./INSTALL.md) document.
+
+Please find detailed installation instructions and options in the [INSTALL](./INSTALL.md) document.
 
 
 ## FAQ
 
-Please see
-[our wiki FAQ pages](https://github.com/BrendelGroup/AEGeAn/wiki/FAQ)
-for usage examples and suggestions.
+Please see [our wiki FAQ pages](https://github.com/BrendelGroup/AEGeAn/wiki/FAQ) for usage examples and suggestions.
 
 
+## Documentation
 
-Copyright (c) 2010-2016, Daniel S. Standage and [CONTRIBUTORS](https://github.com/BrendelGroup/AEGeAn/blob/master/docs/contrib.rst).
-See LICENSE and for details.
-Project homepage: http://brendelgroup.github.io/AEGeAn.
+The main AEGeAn Toolkit documentation is available at https://aegean.readthedocs.io/en/stable/.
+This documentation is focused on the core C library and the programs that directly call this library.
 
-[![AEGeAn build status](https://api.travis-ci.org/BrendelGroup/AEGeAn.svg?branch=master)](https://travis-ci.org/BrendelGroup/AEGeAn)
-[![ReadTheDocs build status](https://readthedocs.org/projects/aegean/badge/?version=latest)](https://readthedocs.org/projects/aegean/badge/?version=latest)
+Documentation for the fidibus module, recently merged into AEGeAn, is available from the original (and now deprecated) GenHub project.
+
+- user manual: https://github.com/standage/genhub/blob/master/docs/MANUAL.md
+- developer documentation: https://github.com/standage/genhub/blob/master/docs/DEVELOP.md
+
+We are in the process of combining and standardizing these separate sources of documentation.
+
+
+## Contact
+
+Please direct all comments and suggestions to [Volker Brendel](<mailto:vbrendel@indiana.edu>) or [Daniel Standage](<mailto:daniel.standage@nbacc.dhs.gov>).

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This documentation is focused on the core C library and the programs that direct
 
 Documentation for the fidibus module, recently merged into AEGeAn, is available from the original (and now deprecated) GenHub project.
 
+- quick start: https://github.com/standage/genhub/#quick-start-example-usages
 - user manual: https://github.com/standage/genhub/blob/master/docs/MANUAL.md
 - developer documentation: https://github.com/standage/genhub/blob/master/docs/DEVELOP.md
 

--- a/docs/contrib.rst
+++ b/docs/contrib.rst
@@ -4,10 +4,12 @@ The following assisted in the development of the AEGeAn Toolkit and/or
 contributed to its code base.
 
 * Daniel S. Standage <daniel.standage@gmail.com>, primary developer
-* Volker Brendel <vbrendel@indiana.edu>, intellectual development, supervision,
+* Volker Brendel <vbrendel@indiana.edu>, contributing developer, supervision,
   and testing
 * Sascha Steinbiss <steinbiss@zbh.uni-hamburg.de> and Gordon Gremme
   <gordon@gremme.org>, integration with GenomeTools, including code examples
   and implementing feature requests
 * James Denton <jfdenton@indiana.edu>, testing compatibility of LocusPocus with
   NCBI annotations (produced by annotwriter), scripts for tidying GFF3 input
+* Tim Lai <timlai@iu.edu>, testing and refinement of fidibus species
+  configuration

--- a/docs/contrib.rst
+++ b/docs/contrib.rst
@@ -4,8 +4,8 @@ The following assisted in the development of the AEGeAn Toolkit and/or
 contributed to its code base.
 
 * Daniel S. Standage <daniel.standage@gmail.com>, primary developer
-* Volker Brendel <vbrendel@indiana.edu>, contributing developer, supervision,
-  and testing
+* Volker Brendel <vbrendel@indiana.edu>, contributing developer, conceptual
+  development and supervision, and testing
 * Sascha Steinbiss <steinbiss@zbh.uni-hamburg.de> and Gordon Gremme
   <gordon@gremme.org>, integration with GenomeTools, including code examples
   and implementing feature requests

--- a/fidibus/fidibus/__init__.py
+++ b/fidibus/fidibus/__init__.py
@@ -2,11 +2,10 @@
 # coding: utf-8
 #
 # -----------------------------------------------------------------------------
-# Copyright (c) 2015-2016   Daniel Standage <daniel.standage@gmail.com>
 # Copyright (c) 2015-2016   Indiana University
 #
-# This file is part of fidibus (http://github.com/standage/fidibus) and is
-# licensed under the BSD 3-clause license: see LICENSE.txt.
+# This file is part of AEGeAn (http://github.com/BrendelGroup/AEGeAn) and is
+# licensed under the ISC license: see LICENSE.
 # -----------------------------------------------------------------------------
 
 """Package-wide configuration"""

--- a/fidibus/fidibus/am10.py
+++ b/fidibus/fidibus/am10.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 #
 # -----------------------------------------------------------------------------
-# Copyright (c) 2016   Daniel Standage <daniel.standage@gmail.com>
 # Copyright (c) 2016   Indiana University
 #
-# This file is part of fidibus (http://github.com/standage/fidibus) and is
-# licensed under the BSD 3-clause license: see LICENSE.txt.
+# This file is part of AEGeAn (http://github.com/BrendelGroup/AEGeAn) and is
+# licensed under the ISC license: see LICENSE.
 # -----------------------------------------------------------------------------
 
 """Custom Genome database implementation for *Apis mellifera* OGS 1.0."""

--- a/fidibus/fidibus/cdhit.py
+++ b/fidibus/fidibus/cdhit.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 #
 # -----------------------------------------------------------------------------
-# Copyright (c) 2016   Daniel Standage <daniel.standage@gmail.com>
 # Copyright (c) 2016   Indiana University
 #
-# This file is part of fidibus (http://github.com/standage/fidibus) and is
-# licensed under the BSD 3-clause license: see LICENSE.txt.
+# This file is part of AEGeAn (http://github.com/BrendelGroup/AEGeAn) and is
+# licensed under the ISC license: see LICENSE.
 # -----------------------------------------------------------------------------
 
 """Module for handling cd-hit output."""

--- a/fidibus/fidibus/crg.py
+++ b/fidibus/fidibus/crg.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 #
 # -----------------------------------------------------------------------------
-# Copyright (c) 2015-2016   Daniel Standage <daniel.standage@gmail.com>
 # Copyright (c) 2015-2016   Indiana University
 #
-# This file is part of fidibus (http://github.com/standage/fidibus) and is
-# licensed under the BSD 3-clause license: see LICENSE.txt.
+# This file is part of AEGeAn (http://github.com/BrendelGroup/AEGeAn) and is
+# licensed under the ISC license: see LICENSE.
 # -----------------------------------------------------------------------------
 
 """

--- a/fidibus/fidibus/download.py
+++ b/fidibus/fidibus/download.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 #
 # -----------------------------------------------------------------------------
-# Copyright (c) 2015-2016   Daniel Standage <daniel.standage@gmail.com>
 # Copyright (c) 2015-2016   Indiana University
 # Copyright (c) 2016        The Regents of the University of California
 #
-# This file is part of fidibus (http://github.com/standage/fidibus) and is
-# licensed under the BSD 3-clause license: see LICENSE.txt.
+# This file is part of AEGeAn (http://github.com/BrendelGroup/AEGeAn) and is
+# licensed under the ISC license: see LICENSE.
 # -----------------------------------------------------------------------------
 
 """Simple module for downloading data with PycURL"""

--- a/fidibus/fidibus/exons.py
+++ b/fidibus/fidibus/exons.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 #
 # -----------------------------------------------------------------------------
-# Copyright (c) 2016   Daniel Standage <daniel.standage@gmail.com>
 # Copyright (c) 2016   Indiana University
 #
-# This file is part of fidibus (http://github.com/standage/fidibus) and is
-# licensed under the BSD 3-clause license: see LICENSE.txt.
+# This file is part of AEGeAn (http://github.com/BrendelGroup/AEGeAn) and is
+# licensed under the ISC license: see LICENSE.
 # -----------------------------------------------------------------------------
 
 from __future__ import print_function

--- a/fidibus/fidibus/fasta.py
+++ b/fidibus/fidibus/fasta.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 #
 # -----------------------------------------------------------------------------
-# Copyright (c) 2015   Daniel Standage <daniel.standage@gmail.com>
 # Copyright (c) 2015   Indiana University
 #
-# This file is part of fidibus (http://github.com/standage/fidibus) and is
-# licensed under the BSD 3-clause license: see LICENSE.txt.
+# This file is part of AEGeAn (http://github.com/BrendelGroup/AEGeAn) and is
+# licensed under the ISC license: see LICENSE.
 # -----------------------------------------------------------------------------
 
 """Simple module for reading, writing, subsetting, and comparing sequences."""

--- a/fidibus/fidibus/generic.py
+++ b/fidibus/fidibus/generic.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 #
 # -----------------------------------------------------------------------------
-# Copyright (c) 2016   Daniel Standage <daniel.standage@gmail.com>
 # Copyright (c) 2016   Indiana University
 #
-# This file is part of fidibus (http://github.com/standage/fidibus) and is
-# licensed under the BSD 3-clause license: see LICENSE.txt.
+# This file is part of AEGeAn (http://github.com/BrendelGroup/AEGeAn) and is
+# licensed under the ISC license: see LICENSE.
 # -----------------------------------------------------------------------------
 
 """

--- a/fidibus/fidibus/genomedb.py
+++ b/fidibus/fidibus/genomedb.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 #
 # -----------------------------------------------------------------------------
-# Copyright (c) 2015-2016   Daniel Standage <daniel.standage@gmail.com>
 # Copyright (c) 2015-2016   Indiana University
 #
-# This file is part of fidibus (http://github.com/standage/fidibus) and is
-# licensed under the BSD 3-clause license: see LICENSE.txt.
+# This file is part of AEGeAn (http://github.com/BrendelGroup/AEGeAn) and is
+# licensed under the ISC license: see LICENSE.
 # -----------------------------------------------------------------------------
 
 """

--- a/fidibus/fidibus/hymbase.py
+++ b/fidibus/fidibus/hymbase.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 #
 # -----------------------------------------------------------------------------
-# Copyright (c) 2017   Daniel Standage <daniel.standage@gmail.com>
 # Copyright (c) 2017   Regents of the University of California.
 #
-# This file is part of fidibus (http://github.com/standage/fidibus) and is
-# licensed under the BSD 3-clause license: see LICENSE.txt.
+# This file is part of AEGeAn (http://github.com/BrendelGroup/AEGeAn) and is
+# licensed under the ISC license: see LICENSE.
 # -----------------------------------------------------------------------------
 
 """

--- a/fidibus/fidibus/iloci.py
+++ b/fidibus/fidibus/iloci.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 #
 # -----------------------------------------------------------------------------
-# Copyright (c) 2015-2016   Daniel Standage <daniel.standage@gmail.com>
 # Copyright (c) 2015-2016   Indiana University
 #
-# This file is part of fidibus (http://github.com/standage/fidibus) and is
-# licensed under the BSD 3-clause license: see LICENSE.txt.
+# This file is part of AEGeAn (http://github.com/BrendelGroup/AEGeAn) and is
+# licensed under the ISC license: see LICENSE.
 # -----------------------------------------------------------------------------
 
 from __future__ import print_function

--- a/fidibus/fidibus/mrnas.py
+++ b/fidibus/fidibus/mrnas.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 #
 # -----------------------------------------------------------------------------
-# Copyright (c) 2016   Daniel Standage <daniel.standage@gmail.com>
 # Copyright (c) 2016   Indiana University
 #
-# This file is part of fidibus (http://github.com/standage/fidibus) and is
-# licensed under the BSD 3-clause license: see LICENSE.txt.
+# This file is part of AEGeAn (http://github.com/BrendelGroup/AEGeAn) and is
+# licensed under the ISC license: see LICENSE.
 # -----------------------------------------------------------------------------
 
 from __future__ import print_function

--- a/fidibus/fidibus/pdom.py
+++ b/fidibus/fidibus/pdom.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 #
 # -----------------------------------------------------------------------------
-# Copyright (c) 2015-2016   Daniel Standage <daniel.standage@gmail.com>
 # Copyright (c) 2015-2016   Indiana University
 #
-# This file is part of fidibus (http://github.com/standage/fidibus) and is
-# licensed under the BSD 3-clause license: see LICENSE.txt.
+# This file is part of AEGeAn (http://github.com/BrendelGroup/AEGeAn) and is
+# licensed under the ISC license: see LICENSE.
 # -----------------------------------------------------------------------------
 
 """

--- a/fidibus/fidibus/proteins.py
+++ b/fidibus/fidibus/proteins.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 #
 # -----------------------------------------------------------------------------
-# Copyright (c) 2016   Daniel Standage <daniel.standage@gmail.com>
 # Copyright (c) 2016   Indiana University
 # Copyright (c) 2016   The Regents of the University of California
 #
-# This file is part of fidibus (http://github.com/standage/fidibus) and is
-# licensed under the BSD 3-clause license: see LICENSE.txt.
+# This file is part of AEGeAn (http://github.com/BrendelGroup/AEGeAn) and is
+# licensed under the ISC license: see LICENSE.
 # -----------------------------------------------------------------------------
 
 from __future__ import print_function

--- a/fidibus/fidibus/refseq.py
+++ b/fidibus/fidibus/refseq.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 #
 # -----------------------------------------------------------------------------
-# Copyright (c) 2015-2016   Daniel Standage <daniel.standage@gmail.com>
 # Copyright (c) 2015-2016   Indiana University
 #
-# This file is part of fidibus (http://github.com/standage/fidibus) and is
-# licensed under the BSD 3-clause license: see LICENSE.txt.
+# This file is part of AEGeAn (http://github.com/BrendelGroup/AEGeAn) and is
+# licensed under the ISC license: see LICENSE.
 # -----------------------------------------------------------------------------
 
 """

--- a/fidibus/fidibus/registry.py
+++ b/fidibus/fidibus/registry.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 #
 # -----------------------------------------------------------------------------
-# Copyright (c) 2015-2016   Daniel Standage <daniel.standage@gmail.com>
 # Copyright (c) 2015-2016   Indiana University
 #
-# This file is part of fidibus (http://github.com/standage/fidibus) and is
-# licensed under the BSD 3-clause license: see LICENSE.txt.
+# This file is part of AEGeAn (http://github.com/BrendelGroup/AEGeAn) and is
+# licensed under the ISC license: see LICENSE.
 # -----------------------------------------------------------------------------
 
 """Module implementing a registry for handling genome configuration files."""

--- a/fidibus/fidibus/stats.py
+++ b/fidibus/fidibus/stats.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 #
 # -----------------------------------------------------------------------------
-# Copyright (c) 2016   Daniel Standage <daniel.standage@gmail.com>
 # Copyright (c) 2016   Indiana University
 #
-# This file is part of fidibus (http://github.com/standage/fidibus) and is
-# licensed under the BSD 3-clause license: see LICENSE.txt.
+# This file is part of AEGeAn (http://github.com/BrendelGroup/AEGeAn) and is
+# licensed under the ISC license: see LICENSE.
 # -----------------------------------------------------------------------------
 
 from __future__ import print_function

--- a/fidibus/fidibus/tair.py
+++ b/fidibus/fidibus/tair.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 #
 # -----------------------------------------------------------------------------
-# Copyright (c) 2016   Daniel Standage <daniel.standage@gmail.com>
 # Copyright (c) 2016   Indiana University
 #
-# This file is part of fidibus (http://github.com/standage/fidibus) and is
-# licensed under the BSD 3-clause license: see LICENSE.txt.
+# This file is part of AEGeAn (http://github.com/BrendelGroup/AEGeAn) and is
+# licensed under the ISC license: see LICENSE.
 # -----------------------------------------------------------------------------
 
 """

--- a/fidibus/scripts/fidibus
+++ b/fidibus/scripts/fidibus
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 #
 # -----------------------------------------------------------------------------
-# Copyright (c) 2015-2016   Daniel Standage <daniel.standage@gmail.com>
 # Copyright (c) 2015-2016   Indiana University
 #
-# This file is part of fidibus (http://github.com/standage/fidibus) and is
-# licensed under the BSD 3-clause license: see LICENSE.txt.
+# This file is part of AEGeAn (http://github.com/BrendelGroup/AEGeAn) and is
+# licensed under the ISC license: see LICENSE.
 # -----------------------------------------------------------------------------
 
 from __future__ import print_function

--- a/fidibus/scripts/fidibus-compact.py
+++ b/fidibus/scripts/fidibus-compact.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 #
 # -----------------------------------------------------------------------------
-# Copyright (c) 2016   Daniel Standage <daniel.standage@gmail.com>
 # Copyright (c) 2016   Indiana University
 #
-# This file is part of fidibus (http://github.com/standage/fidibus) and is
-# licensed under the BSD 3-clause license: see LICENSE.txt.
+# This file is part of AEGeAn (http://github.com/BrendelGroup/AEGeAn) and is
+# licensed under the ISC license: see LICENSE.
 # -----------------------------------------------------------------------------
 
 from __future__ import print_function

--- a/fidibus/scripts/fidibus-filens.py
+++ b/fidibus/scripts/fidibus-filens.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 #
 # -----------------------------------------------------------------------------
-# Copyright (c) 2015   Daniel Standage <daniel.standage@gmail.com>
 # Copyright (c) 2015   Indiana University
 #
-# This file is part of fidibus (http://github.com/standage/fidibus) and is
-# licensed under the BSD 3-clause license: see LICENSE.txt.
+# This file is part of AEGeAn (http://github.com/BrendelGroup/AEGeAn) and is
+# licensed under the ISC license: see LICENSE.
 # -----------------------------------------------------------------------------
 
 from __future__ import print_function

--- a/fidibus/scripts/fidibus-format-gff3.py
+++ b/fidibus/scripts/fidibus-format-gff3.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 #
 # -----------------------------------------------------------------------------
-# Copyright (c) 2015-2016   Daniel Standage <daniel.standage@gmail.com>
 # Copyright (c) 2015-2016   Indiana University
 #
-# This file is part of fidibus (http://github.com/standage/fidibus) and is
-# licensed under the BSD 3-clause license: see LICENSE.txt.
+# This file is part of AEGeAn (http://github.com/BrendelGroup/AEGeAn) and is
+# licensed under the ISC license: see LICENSE.
 # -----------------------------------------------------------------------------
 
 from __future__ import print_function

--- a/fidibus/scripts/fidibus-glean-to-gff3.py
+++ b/fidibus/scripts/fidibus-glean-to-gff3.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 #
 # -----------------------------------------------------------------------------
-# Copyright (c) 2016   Daniel Standage <daniel.standage@gmail.com>
 # Copyright (c) 2016   Indiana University
 #
-# This file is part of fidibus (http://github.com/standage/fidibus) and is
-# licensed under the BSD 3-clause license: see LICENSE.txt.
+# This file is part of AEGeAn (http://github.com/BrendelGroup/AEGeAn) and is
+# licensed under the ISC license: see LICENSE.
 # -----------------------------------------------------------------------------
 
 from __future__ import print_function

--- a/fidibus/scripts/fidibus-ilocus-summary.py
+++ b/fidibus/scripts/fidibus-ilocus-summary.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 #
 # -----------------------------------------------------------------------------
-# Copyright (c) 2016   Daniel Standage <daniel.standage@gmail.com>
 # Copyright (c) 2016   Indiana University
 #
 # This file is part of AEGeAn (http://github.com/BrendelGroup/AEGeAn) and is

--- a/fidibus/scripts/fidibus-milocus-summary.py
+++ b/fidibus/scripts/fidibus-milocus-summary.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 #
 # -----------------------------------------------------------------------------
-# Copyright (c) 2016   Daniel Standage <daniel.standage@gmail.com>
 # Copyright (c) 2016   Indiana University
 #
 # This file is part of AEGeAn (http://github.com/BrendelGroup/AEGeAn) and is

--- a/fidibus/scripts/fidibus-monitor-refseq.py
+++ b/fidibus/scripts/fidibus-monitor-refseq.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 #
 # -----------------------------------------------------------------------------
-# Copyright (c) 2016   Daniel Standage <daniel.standage@gmail.com>
 # Copyright (c) 2016   Indiana University
 # Copyright (c) 2016   The Regents of the University of California
 #
-# This file is part of fidibus (http://github.com/standage/fidibus) and is
-# licensed under the BSD 3-clause license: see LICENSE.txt.
+# This file is part of AEGeAn (http://github.com/BrendelGroup/AEGeAn) and is
+# licensed under the ISC license: see LICENSE.
 # -----------------------------------------------------------------------------
 
 from __future__ import print_function

--- a/fidibus/scripts/fidibus-namedup.py
+++ b/fidibus/scripts/fidibus-namedup.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 #
 # -----------------------------------------------------------------------------
-# Copyright (c) 2015   Daniel Standage <daniel.standage@gmail.com>
 # Copyright (c) 2015   Indiana University
 #
-# This file is part of fidibus (http://github.com/standage/fidibus) and is
-# licensed under the BSD 3-clause license: see LICENSE.txt.
+# This file is part of AEGeAn (http://github.com/BrendelGroup/AEGeAn) and is
+# licensed under the ISC license: see LICENSE.
 # -----------------------------------------------------------------------------
 """
 Process a GFF3 file, and for any feature that has an ID but lacks a `Name`

--- a/fidibus/scripts/fidibus-pilocus-summary.py
+++ b/fidibus/scripts/fidibus-pilocus-summary.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 #
 # -----------------------------------------------------------------------------
-# Copyright (c) 2016   Daniel Standage <daniel.standage@gmail.com>
 # Copyright (c) 2016   Indiana University
 #
 # This file is part of AEGeAn (http://github.com/BrendelGroup/AEGeAn) and is

--- a/fidibus/scripts/fidibus-stats.py
+++ b/fidibus/scripts/fidibus-stats.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 #
 # -----------------------------------------------------------------------------
-# Copyright (c) 2015-2016   Daniel Standage <daniel.standage@gmail.com>
 # Copyright (c) 2015-2016   Indiana University
 #
-# This file is part of fidibus (http://github.com/standage/fidibus) and is
-# licensed under the BSD 3-clause license: see LICENSE.txt.
+# This file is part of AEGeAn (http://github.com/BrendelGroup/AEGeAn) and is
+# licensed under the ISC license: see LICENSE.
 # -----------------------------------------------------------------------------
 
 from __future__ import print_function

--- a/fidibus/scripts/fidibus-uniq.py
+++ b/fidibus/scripts/fidibus-uniq.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 #
 # -----------------------------------------------------------------------------
-# Copyright (c) 2015   Daniel Standage <daniel.standage@gmail.com>
 # Copyright (c) 2015   Indiana University
 #
-# This file is part of fidibus (http://github.com/standage/fidibus) and is
-# licensed under the BSD 3-clause license: see LICENSE.txt.
+# This file is part of AEGeAn (http://github.com/BrendelGroup/AEGeAn) and is
+# licensed under the ISC license: see LICENSE.
 # -----------------------------------------------------------------------------
 
 from __future__ import print_function

--- a/fidibus/setup.py
+++ b/fidibus/setup.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 #
 # -----------------------------------------------------------------------------
-# Copyright (c) 2015-2016   Daniel Standage <daniel.standage@gmail.com>
 # Copyright (c) 2015-2016   Indiana University
 # Copyright (c) 2016        The Regents of the University of California
 #
-# This file is part of fidibus (http://github.com/standage/fidibus) and is
-# licensed under the BSD 3-clause license: see LICENSE.txt.
+# This file is part of AEGeAn (http://github.com/BrendelGroup/AEGeAn) and is
+# licensed under the ISC license: see LICENSE.
 # -----------------------------------------------------------------------------
 
 """Setup configuration for fidibus"""


### PR DESCRIPTION
This PR includes the following updates.

- update contributor notes
- fix license headers
    - fidibus --> AEGeAn
    - BSD --> ISC
    - drop Daniel Standage (I'm no longer the sole code contributor; contributions noted instead in `docs/contrib.rst`)
- update README
    - more detailed description
    - reference to RAMOSE philosophy
    - references to all sources of documentation

Closes #201.