### PR TITLE
updated sigma/phi calculation intended to provided balanced effective…

### DIFF
--- a/LocusPocus/LocusPocus/generic.py
+++ b/LocusPocus/LocusPocus/generic.py
@@ -160,6 +160,6 @@ def test_all():
     LocusPocus.exons.prepare(db, logstream=None)
     LocusPocus.stats.compute(db, logstream=None)
 
-    sha1 = 'f3629aedbd683dd4dcf158ac12d3549e5c9081a0'
+    sha1 = '786122acdda794e3a63eff8a094d1dfa3e2afc75'
     testsha1 = db.file_sha1('testdata/demo-workdir/Gnrc/Gnrc.iloci.tsv')
     assert testsha1 == sha1, ('generic iLocus stats checksum failed')

--- a/LocusPocus/scripts/fidibus-compact.py
+++ b/LocusPocus/scripts/fidibus-compact.py
@@ -101,12 +101,16 @@ def det_ilspace(seqid, iloci, ithresh=None, gthresh=None):
 
 def calc_phi(seqid, iloci, miloci, gthresh=None):
     gilocus_types = ['siLocus', 'ciLocus', 'niLocus']
-    giloci = iloci.loc[(iloci.SeqID == seqid) &
-                       (iloci.LocusClass.isin(gilocus_types))]
-    singletons = miloci.loc[(miloci.SeqID == seqid) &
-                            (miloci.LocusClass.isin(gilocus_types))]
+    giloci = iloci.loc[
+        (iloci.SeqID == seqid) &
+        (iloci.LocusClass.isin(gilocus_types))
+    ]
+    singletons = miloci.loc[
+        (miloci.SeqID == seqid) &
+        (miloci.LocusClass.isin(gilocus_types))
+    ]
     if gthresh:
-        giloci     = giloci.loc[giloci.Length         >= gthresh]
+        giloci = giloci.loc[giloci.Length >= gthresh]
         singletons = singletons.loc[singletons.Length >= gthresh]
     nbrmerged = len(giloci) - len(singletons)
     return nbrmerged / len(giloci)
@@ -163,14 +167,17 @@ def main(args):
                 continue
 
             ilspace = det_ilspace(seqid, miloci, ithresh, gthresh)
-            mispace = miloci.loc[(miloci.SeqID == seqid) &
-                                 (miloci.LocusClass == 'miLocus')
-                                ]['Length'].sum()
+            mispace = miloci.loc[
+                (miloci.SeqID == seqid) &
+                (miloci.LocusClass == 'miLocus')
+            ]['Length'].sum()
             if gthresh:
-               shortmiloci = miloci.loc[(miloci.SeqID == seqid) &
-                                        (miloci.LocusClass == 'miLocus') &
-                                        (miloci.Length < gthresh)]
-               mispace -= shortmiloci['Length'].sum()
+                shortmiloci = miloci.loc[
+                    (miloci.SeqID == seqid) &
+                    (miloci.LocusClass == 'miLocus') &
+                    (miloci.Length < gthresh)
+                ]
+                mispace -= shortmiloci['Length'].sum()
             sigma = mispace / ilspace
 
             seqids.append(seqid)

--- a/LocusPocus/testdata/gff3/bdis-iloci.gff3
+++ b/LocusPocus/testdata/gff3/bdis-iloci.gff3
@@ -19,7 +19,7 @@ NW_014576703.1	Gnomon	exon	1214	2342	.	+	.	Parent=mRNA1;Dbxref=GeneID:100844543,
 ###
 NW_014576703.1	AEGeAn::LocusPocus	locus	2843	23566	.	.	.	Name=BdisILC-00002;effective_length=20724;iLocus_type=fiLocus
 NW_014576707.1	AEGeAn::LocusPocus	locus	1	6765	.	.	.	Name=BdisILC-00003;effective_length=6765;iLocus_type=fiLocus
-NW_014576707.1	AEGeAn::LocusPocus	locus	6766	11442	.	.	.	ID=locus2;Name=BdisILC-00004;child_gene=1;child_mRNA=5;right_overlap=395;iiLocus_exception=delta-overlap-delta;riil=0;effective_length=4282;iLocus_type=siLocus
+NW_014576707.1	AEGeAn::LocusPocus	locus	6766	11442	.	.	.	ID=locus2;Name=BdisILC-00004;child_gene=1;child_mRNA=5;right_overlap=395;iiLocus_exception=delta-overlap-delta;riil=0;effective_length=4480;iLocus_type=siLocus
 NW_014576707.1	Gnomon	gene	7266	10942	.	-	.	ID=gene2;Parent=locus2;Dbxref=GeneID:100822410;Name=LOC100822410;gbkey=Gene;gene=LOC100822410;gene_biotype=protein_coding;accession=100822410
 NW_014576707.1	Gnomon	mRNA	7266	10942	.	-	.	ID=mRNA2;Parent=gene2;Dbxref=GeneID:100822410,Genbank:XM_014896223.1;Name=XM_014896223.1;gbkey=mRNA;gene=LOC100822410;product=uncharacterized LOC100822410%2C transcript variant X2;transcript_id=XM_014896223.1;accession=XM_014896223.1
 NW_014576707.1	Gnomon	exon	7266	7716	.	-	.	Parent=mRNA2;Dbxref=GeneID:100822410,Genbank:XM_014896223.1;gbkey=mRNA;gene=LOC100822410;product=uncharacterized LOC100822410%2C transcript variant X2;transcript_id=XM_014896223.1;accession=XM_014896223.1
@@ -69,7 +69,7 @@ NW_014576707.1	Gnomon	CDS	8190	8427	.	-	0	ID=CDS6;Parent=mRNA6;Dbxref=GeneID:100
 NW_014576707.1	Gnomon	CDS	8751	8819	.	-	0	ID=CDS6;Parent=mRNA6;Dbxref=GeneID:100822410,Genbank:XP_014751710.1;Name=XP_014751710.1;gbkey=CDS;gene=LOC100822410;product=uncharacterized protein LOC100822410 isoform X2;protein_id=XP_014751710.1;accession=XM_014896224.1
 NW_014576707.1	Gnomon	exon	8751	10942	.	-	.	Parent=mRNA6;Dbxref=GeneID:100822410,Genbank:XM_014896224.1;gbkey=mRNA;gene=LOC100822410;product=uncharacterized LOC100822410%2C transcript variant X3;transcript_id=XM_014896224.1;accession=XM_014896224.1
 ###
-NW_014576707.1	AEGeAn::LocusPocus	locus	11048	15857	.	.	.	ID=locus3;left_overlap=395;liil=0;Name=BdisILC-00005;child_gene=1;child_mRNA=1;right_overlap=624;iiLocus_exception=delta-overlap-gene;riil=0;effective_length=4186;iLocus_type=siLocus
+NW_014576707.1	AEGeAn::LocusPocus	locus	11048	15857	.	.	.	ID=locus3;left_overlap=395;liil=0;Name=BdisILC-00005;child_gene=1;child_mRNA=1;right_overlap=624;iiLocus_exception=delta-overlap-gene;riil=0;effective_length=4300;iLocus_type=siLocus
 NW_014576707.1	Gnomon	gene	11548	15357	.	-	.	ID=gene3;Parent=locus3;Dbxref=GeneID:100822717;Name=LOC100822717;gbkey=Gene;gene=LOC100822717;gene_biotype=protein_coding;accession=100822717
 NW_014576707.1	Gnomon	mRNA	11548	15357	.	-	.	ID=mRNA7;Parent=gene3;Dbxref=GeneID:100822717,Genbank:XM_014896227.1;Name=XM_014896227.1;gbkey=mRNA;gene=LOC100822717;product=disease resistance protein RGA2-like;transcript_id=XM_014896227.1;accession=XM_014896227.1
 NW_014576707.1	Gnomon	exon	11548	11613	.	-	.	Parent=mRNA7;Dbxref=GeneID:100822717,Genbank:XM_014896227.1;gbkey=mRNA;gene=LOC100822717;product=disease resistance protein RGA2-like;transcript_id=XM_014896227.1;accession=XM_014896227.1
@@ -78,7 +78,7 @@ NW_014576707.1	Gnomon	CDS	11794	13533	.	-	0	ID=CDS7;Parent=mRNA7;Dbxref=GeneID:1
 NW_014576707.1	Gnomon	CDS	13952	15265	.	-	0	ID=CDS7;Parent=mRNA7;Dbxref=GeneID:100822717,Genbank:XP_014751713.1;Name=XP_014751713.1;gbkey=CDS;gene=LOC100822717;product=disease resistance protein RGA2-like;protein_id=XP_014751713.1;accession=XM_014896227.1
 NW_014576707.1	Gnomon	exon	13952	15357	.	-	.	Parent=mRNA7;Dbxref=GeneID:100822717,Genbank:XM_014896227.1;gbkey=mRNA;gene=LOC100822717;product=disease resistance protein RGA2-like;transcript_id=XM_014896227.1;accession=XM_014896227.1
 ###
-NW_014576707.1	AEGeAn::LocusPocus	locus	15234	16400	.	.	.	ID=locus4;left_overlap=624;liil=0;Name=BdisILC-00006;child_gene=1;child_ncRNA=1;effective_length=1167;iLocus_type=niLocus
+NW_014576707.1	AEGeAn::LocusPocus	locus	15234	16400	.	.	.	ID=locus4;left_overlap=624;liil=0;Name=BdisILC-00006;child_gene=1;child_ncRNA=1;effective_length=855;iLocus_type=niLocus
 NW_014576707.1	Gnomon	gene	15734	16389	.	-	.	ID=gene4;Parent=locus4;Dbxref=GeneID:104581480;Name=LOC104581480;gbkey=Gene;gene=LOC104581480;gene_biotype=lncRNA;accession=104581480
 NW_014576707.1	Gnomon	ncRNA	15734	16389	.	-	.	ID=ncRNA1;Parent=gene4;Dbxref=GeneID:104581480,Genbank:XR_729446.2;Name=XR_729446.2;gbkey=ncRNA;gene=LOC104581480;ncrna_class=lncRNA;product=uncharacterized LOC104581480;transcript_id=XR_729446.2;accession=XR_729446.2
 NW_014576707.1	Gnomon	exon	15734	16183	.	-	.	Parent=ncRNA1;Dbxref=GeneID:104581480,Genbank:XR_729446.2;gbkey=ncRNA;gene=LOC104581480;ncrna_class=lncRNA;product=uncharacterized LOC104581480;transcript_id=XR_729446.2;accession=XR_729446.2

--- a/data/gff3/nvit-exospindle-out.gff3
+++ b/data/gff3/nvit-exospindle-out.gff3
@@ -6,7 +6,7 @@
 #!genome-build-accession NCBI_Assembly:GCF_000002325.3
 #!annotation-date 3 June 2014
 #!annotation-source NCBI Nasonia vitripennis Annotation Release 101
-NC_015867.2	AEGeAn::LocusPocus	locus	370926	373152	.	.	.	child_gene=1;child_mRNA=1;right_overlap=262;iiLocus_exception=delta-overlap-delta;riil=0;effective_length=1965;iLocus_type=siLocus
-NC_015867.2	AEGeAn::LocusPocus	locus	372891	380536	.	.	.	iLocus_type=ciLocus;effective_length=6758;child_gene=1;child_mRNA=1
+NC_015867.2	AEGeAn::LocusPocus	locus	370926	373152	.	.	.	child_gene=1;child_mRNA=1;right_overlap=262;iiLocus_exception=delta-overlap-delta;riil=0;effective_length=2096;iLocus_type=siLocus
+NC_015867.2	AEGeAn::LocusPocus	locus	372891	380536	.	.	.	iLocus_type=ciLocus;effective_length=7071;child_gene=1;child_mRNA=1
 NC_015867.2	AEGeAn::LocusPocus	locus	374998	378903	.	.	.	iiLocus_exception=intron-gene;iLocus_type=siLocus;child_gene=1;child_mRNA=1
-NC_015867.2	AEGeAn::LocusPocus	locus	379649	381835	.	.	.	left_overlap=888;liil=0;child_gene=1;child_mRNA=1;effective_length=2187;iLocus_type=siLocus
+NC_015867.2	AEGeAn::LocusPocus	locus	379649	381835	.	.	.	left_overlap=888;liil=0;child_gene=1;child_mRNA=1;effective_length=1743;iLocus_type=siLocus

--- a/src/core/AgnLocusRefineStream.c
+++ b/src/core/AgnLocusRefineStream.c
@@ -442,7 +442,7 @@ static void locus_refine_stream_extend(AgnLocusRefineStream *stream,
       if(i == 0)
       {
         char lenstr[32];
-        sprintf(lenstr, "%lu", gt_range_length(&origrange) - (long int)floor(origro/2.0));
+	sprintf(lenstr, "%lu", gt_range_length(&origrange) - (long int)ceil(origlo/2.0) - (long int)floor(origro/2.0));
         gt_feature_node_add_attribute(fn, "effective_length", lenstr);
         if(numloci == 2)
         {

--- a/src/core/AgnLocusRefineStream.c
+++ b/src/core/AgnLocusRefineStream.c
@@ -442,7 +442,7 @@ static void locus_refine_stream_extend(AgnLocusRefineStream *stream,
       if(i == 0)
       {
         char lenstr[32];
-	sprintf(lenstr, "%lu", gt_range_length(&origrange) - (long int)ceil(origlo/2.0) - (long int)floor(origro/2.0));
+        sprintf(lenstr, "%lu", gt_range_length(&origrange) - (long int)ceil(origlo/2.0) - (long int)floor(origro/2.0));
         gt_feature_node_add_attribute(fn, "effective_length", lenstr);
         if(numloci == 2)
         {

--- a/src/core/AgnLocusRefineStream.c
+++ b/src/core/AgnLocusRefineStream.c
@@ -354,6 +354,11 @@ static void locus_refine_stream_extend(AgnLocusRefineStream *stream,
   const char *orig_riil = gt_feature_node_get_attribute(origfn, "riil");
   GtStr *seqid = gt_genome_node_get_seqid(orig);
 
+  GtUword origlo = 0;
+  const char *lostr = gt_feature_node_get_attribute(origfn, "left_overlap");
+  if(lostr)
+    origlo = atol(lostr);
+
   GtUword numloci = gt_array_size(iloci);
   agn_assert(numloci > 0);
 
@@ -437,7 +442,7 @@ static void locus_refine_stream_extend(AgnLocusRefineStream *stream,
       if(i == 0)
       {
         char lenstr[32];
-        sprintf(lenstr, "%lu", gt_range_length(&origrange) - origro);
+        sprintf(lenstr, "%lu", gt_range_length(&origrange) - (long int)floor(origro/2.0));
         gt_feature_node_add_attribute(fn, "effective_length", lenstr);
         if(numloci == 2)
         {
@@ -479,9 +484,6 @@ static void locus_refine_stream_extend(AgnLocusRefineStream *stream,
     }
     if(numloci == 1)
     {
-      char lenstr[32];
-      sprintf(lenstr, "%lu", gt_range_length(&origrange) - origro);
-      gt_feature_node_add_attribute(origfn, "effective_length", lenstr);
       return;
     }
   }
@@ -538,8 +540,8 @@ static void locus_refine_stream_extend(AgnLocusRefineStream *stream,
     {
       agn_assert(origro < gt_range_length(&rng2));
       GtUword overlap = rng1.end - rng2.start + 1;
-      GtUword elen1 = gt_range_length(&rng1) - floor(overlap/2);
-      GtUword elen2 = gt_range_length(&rng2) - ceil(overlap/2) - origro;
+      GtUword elen1 = gt_range_length(&rng1) - (long int)floor(overlap/2.0);
+      GtUword elen2 = gt_range_length(&rng2) - (long int)ceil(overlap/2.0);
       char lenstr1[32];
       char lenstr2[32];
       sprintf(lenstr1, "%lu", elen1);
@@ -592,7 +594,7 @@ static void locus_refine_stream_extend(AgnLocusRefineStream *stream,
       if(i == 0)
       {
         char lenstr[32];
-        sprintf(lenstr, "%lu", gt_range_length(&origrange) - origro);
+        sprintf(lenstr, "%lu", gt_range_length(&origrange) - (long int)ceil(origlo/2.0) - (long int)floor(origro/2.0));
         gt_feature_node_add_attribute(fn, "effective_length", lenstr);
 
         char exceptstr[32];
@@ -671,7 +673,11 @@ static int locus_refine_stream_handler(AgnLocusRefineStream *stream,
     const char *rostr = gt_feature_node_get_attribute(locus, "right_overlap");
     if(rostr != NULL)
       ro = atol(rostr);
-    sprintf(lenstr, "%lu", gt_range_length(&rng) - ro);
+    GtUword lo = 0;
+    const char *lostr = gt_feature_node_get_attribute(locus, "left_overlap");
+    if(lostr != NULL)
+      lo = atol(lostr);
+    sprintf(lenstr, "%lu", gt_range_length(&rng) - (long int)ceil(lo/2.0) - (long int)floor(ro/2.0));
     gt_feature_node_add_attribute(locus, "effective_length", lenstr);
 
     const char *loctype = gt_genome_node_get_user_data(gn, "iLocus_type");


### PR DESCRIPTION
…_length calculation and alllows the -i and -g thresholding

Needs thorough testing beyond my efforts. Key changes:

- overlap lengths get split between upstream and downstream nodes for balanced accounting
- threshold for fidibus-compact.py properly accounts for miLoci cumulative length in case a merged giLocus falls below the cutoff length (which otherwise could lead to sigma values greater than 1)