### PR TITLE
minor change to get rid of a data type warning

### DIFF
--- a/LocusPocus/scripts/fidibus-ilocus-summary.py
+++ b/LocusPocus/scripts/fidibus-ilocus-summary.py
@@ -81,7 +81,7 @@ def main(args):
         ilocustable = '{wd:s}/{spec:s}/{spec:s}.iloci.tsv'.format(
             wd=args.workdir, spec=species
         )
-        data = pandas.read_table(ilocustable)
+        data = pandas.read_table(ilocustable, low_memory=False)
         row = get_row(data, args.outfmt)
         print_row(row, args.outfmt)
 

--- a/LocusPocus/scripts/fidibus-milocus-summary.py
+++ b/LocusPocus/scripts/fidibus-milocus-summary.py
@@ -103,8 +103,8 @@ def main(args):
         milocustable = '{wd:s}/{spec:s}/{spec:s}.mi{dt:s}.tsv'.format(
             wd=args.workdir, spec=species, dt=dtype,
         )
-        iloci = pandas.read_table(ilocustable)
-        miloci = pandas.read_table(milocustable)
+        iloci = pandas.read_table(ilocustable, low_memory=False)
+        miloci = pandas.read_table(milocustable, low_memory=False)
         row = get_row(iloci, miloci, args.outfmt)
         print_row(row, args.outfmt)
 

--- a/LocusPocus/scripts/fidibus-pilocus-summary.py
+++ b/LocusPocus/scripts/fidibus-pilocus-summary.py
@@ -83,8 +83,8 @@ def main(args):
         premrnatable = '{wd:s}/{spec:s}/{spec:s}.pre-mrnas.tsv'.format(
             wd=args.workdir, spec=species
         )
-        iloci = pandas.read_table(ilocustable)
-        premrnas = pandas.read_table(premrnatable)
+        iloci = pandas.read_table(ilocustable, low_memory=False)
+        premrnas = pandas.read_table(premrnatable, low_memory=False)
         row = get_row(iloci, premrnas, args.outfmt)
         print_row(row, args.outfmt)
 


### PR DESCRIPTION
which occurs in panda.read_table(). Not a real issue but slightly annoying. I think this occurs when reading tables that include orientation. We use NA and FF, FR, RF, RR, and I think NA is a different type.